### PR TITLE
Backend-test

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 120
+extend-ignore = E203, F541

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+# .husky/pre-commit
+
+npx lint-staged
+npm run git-test

--- a/Pipfile
+++ b/Pipfile
@@ -8,6 +8,7 @@ black = "*"
 flake8 = "*"
 rope = "*"
 isort = "*"
+pytest = "*"
 
 [packages]
 whoosh = "==2.7.4"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "f0767436e67ca6e459b2dd4bb50ebbc2d4d6659bd5dcf150c1c15a22bda8d0ce"
+            "sha256": "00b33febea44573b48bf0750bc7544f27fa8f4bc626e02945728ebc86918a2a6"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -61,11 +61,11 @@
         },
         "botocore": {
             "hashes": [
-                "sha256:4a1ced1a4218bdff0ed5b46abb54570d473154ddefafa5d121a8d96e4b76ebc1",
-                "sha256:b6a50b853f6d23af9edfed89a59800c6bc1687a947cdd3492879f7d64e002d30"
+                "sha256:06069a06f1352accb1f6c9505d6e323753627112be80a9d2e057c6d9c9779ffd",
+                "sha256:98e3fed636ebb519320c4b2d078db6fa6099b052b4bb9b5c66632a5a7fe72507"
             ],
             "markers": "python_version >= '3.9'",
-            "version": "==1.38.36"
+            "version": "==1.38.41"
         },
         "cffi": {
             "hashes": [
@@ -638,11 +638,11 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:414bc6535b787febd7567804cc015fee39daab8ad86268f1310a9250697de466",
-                "sha256:4e16665048960a0900c702d4a66415956a584919c03361cac9f1df5c5dd7e813"
+                "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760",
+                "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc"
             ],
             "markers": "python_version >= '3.9'",
-            "version": "==2.4.0"
+            "version": "==2.5.0"
         },
         "uvicorn": {
             "extras": [
@@ -700,80 +700,115 @@
         },
         "watchfiles": {
             "hashes": [
-                "sha256:0125f91f70e0732a9f8ee01e49515c35d38ba48db507a50c5bdcad9503af5827",
-                "sha256:0a04059f4923ce4e856b4b4e5e783a70f49d9663d22a4c3b3298165996d1377f",
-                "sha256:0b289572c33a0deae62daa57e44a25b99b783e5f7aed81b314232b3d3c81a11d",
-                "sha256:10f6ae86d5cb647bf58f9f655fcf577f713915a5d69057a0371bc257e2553234",
-                "sha256:13bb21f8ba3248386337c9fa51c528868e6c34a707f729ab041c846d52a0c69a",
-                "sha256:15ac96dd567ad6c71c71f7b2c658cb22b7734901546cd50a475128ab557593ca",
-                "sha256:18b3bd29954bc4abeeb4e9d9cf0b30227f0f206c86657674f544cb032296acd5",
-                "sha256:1909e0a9cd95251b15bff4261de5dd7550885bd172e3536824bf1cf6b121e200",
-                "sha256:1a2902ede862969077b97523987c38db28abbe09fb19866e711485d9fbf0d417",
-                "sha256:1a7bac2bde1d661fb31f4d4e8e539e178774b76db3c2c17c4bb3e960a5de07a2",
-                "sha256:237f9be419e977a0f8f6b2e7b0475ababe78ff1ab06822df95d914a945eac827",
-                "sha256:266710eb6fddc1f5e51843c70e3bebfb0f5e77cf4f27129278c70554104d19ed",
-                "sha256:29c7fd632ccaf5517c16a5188e36f6612d6472ccf55382db6c7fe3fcccb7f59f",
-                "sha256:2b7a21715fb12274a71d335cff6c71fe7f676b293d322722fe708a9ec81d91f5",
-                "sha256:2cfb371be97d4db374cba381b9f911dd35bb5f4c58faa7b8b7106c8853e5d225",
-                "sha256:2cfcb3952350e95603f232a7a15f6c5f86c5375e46f0bd4ae70d43e3e063c13d",
-                "sha256:2f1fefb2e90e89959447bc0420fddd1e76f625784340d64a2f7d5983ef9ad246",
-                "sha256:360a398c3a19672cf93527f7e8d8b60d8275119c5d900f2e184d32483117a705",
-                "sha256:3e380c89983ce6e6fe2dd1e1921b9952fb4e6da882931abd1824c092ed495dec",
-                "sha256:4a8ec1e4e16e2d5bafc9ba82f7aaecfeec990ca7cd27e84fb6f191804ed2fcfc",
-                "sha256:4ab626da2fc1ac277bbf752446470b367f84b50295264d2d313e28dc4405d663",
-                "sha256:4b6227351e11c57ae997d222e13f5b6f1f0700d84b8c52304e8675d33a808382",
-                "sha256:554389562c29c2c182e3908b149095051f81d28c2fec79ad6c8997d7d63e0009",
-                "sha256:5c40fe7dd9e5f81e0847b1ea64e1f5dd79dd61afbedb57759df06767ac719b40",
-                "sha256:68b2dddba7a4e6151384e252a5632efcaa9bc5d1c4b567f3cb621306b2ca9f63",
-                "sha256:7ee32c9a9bee4d0b7bd7cbeb53cb185cf0b622ac761efaa2eba84006c3b3a614",
-                "sha256:830aa432ba5c491d52a15b51526c29e4a4b92bf4f92253787f9726fe01519487",
-                "sha256:832ccc221927c860e7286c55c9b6ebcc0265d5e072f49c7f6456c7798d2b39aa",
-                "sha256:839ebd0df4a18c5b3c1b890145b5a3f5f64063c2a0d02b13c76d78fe5de34936",
-                "sha256:852de68acd6212cd6d33edf21e6f9e56e5d98c6add46f48244bd479d97c967c6",
-                "sha256:85fbb6102b3296926d0c62cfc9347f6237fb9400aecd0ba6bbda94cae15f2b3b",
-                "sha256:86c0df05b47a79d80351cd179893f2f9c1b1cae49d96e8b3290c7f4bd0ca0a92",
-                "sha256:894342d61d355446d02cd3988a7326af344143eb33a2fd5d38482a92072d9563",
-                "sha256:8c0db396e6003d99bb2d7232c957b5f0b5634bbd1b24e381a5afcc880f7373fb",
-                "sha256:8e637810586e6fe380c8bc1b3910accd7f1d3a9a7262c8a78d4c8fb3ba6a2b3d",
-                "sha256:9475b0093767e1475095f2aeb1d219fb9664081d403d1dff81342df8cd707034",
-                "sha256:95cf944fcfc394c5f9de794ce581914900f82ff1f855326f25ebcf24d5397418",
-                "sha256:974866e0db748ebf1eccab17862bc0f0303807ed9cda465d1324625b81293a18",
-                "sha256:9848b21ae152fe79c10dd0197304ada8f7b586d3ebc3f27f43c506e5a52a863c",
-                "sha256:9f4571a783914feda92018ef3901dab8caf5b029325b5fe4558c074582815249",
-                "sha256:a056c2f692d65bf1e99c41045e3bdcaea3cb9e6b5a53dcaf60a5f3bd95fc9763",
-                "sha256:a0dbcb1c2d8f2ab6e0a81c6699b236932bd264d4cef1ac475858d16c403de74d",
-                "sha256:a16512051a822a416b0d477d5f8c0e67b67c1a20d9acecb0aafa3aa4d6e7d256",
-                "sha256:a2014a2b18ad3ca53b1f6c23f8cd94a18ce930c1837bd891262c182640eb40a6",
-                "sha256:a3904d88955fda461ea2531fcf6ef73584ca921415d5cfa44457a225f4a42bc1",
-                "sha256:a74add8d7727e6404d5dc4dcd7fac65d4d82f95928bbee0cf5414c900e86773e",
-                "sha256:ab44e1580924d1ffd7b3938e02716d5ad190441965138b4aa1d1f31ea0877f04",
-                "sha256:b551d4fb482fc57d852b4541f911ba28957d051c8776e79c3b4a51eb5e2a1b11",
-                "sha256:b5eb568c2aa6018e26da9e6c86f3ec3fd958cee7f0311b35c2630fa4217d17f2",
-                "sha256:b659576b950865fdad31fa491d31d37cf78b27113a7671d39f919828587b429b",
-                "sha256:b6e76ceb1dd18c8e29c73f47d41866972e891fc4cc7ba014f487def72c1cf096",
-                "sha256:b7529b5dcc114679d43827d8c35a07c493ad6f083633d573d81c660abc5979e9",
-                "sha256:b9dca99744991fc9850d18015c4f0438865414e50069670f5f7eee08340d8b40",
-                "sha256:ba5552a1b07c8edbf197055bc9d518b8f0d98a1c6a73a293bc0726dce068ed01",
-                "sha256:bfe0cbc787770e52a96c6fda6726ace75be7f840cb327e1b08d7d54eadc3bc85",
-                "sha256:c0901429650652d3f0da90bad42bdafc1f9143ff3605633c455c999a2d786cac",
-                "sha256:cb1489f25b051a89fae574505cc26360c8e95e227a9500182a7fe0afcc500ce0",
-                "sha256:cd47d063fbeabd4c6cae1d4bcaa38f0902f8dc5ed168072874ea11d0c7afc1ff",
-                "sha256:d363152c5e16b29d66cbde8fa614f9e313e6f94a8204eaab268db52231fe5358",
-                "sha256:d5730f3aa35e646103b53389d5bc77edfbf578ab6dab2e005142b5b80a35ef25",
-                "sha256:d6f9367b132078b2ceb8d066ff6c93a970a18c3029cea37bfd7b2d3dd2e5db8f",
-                "sha256:dfd6ae1c385ab481766b3c61c44aca2b3cd775f6f7c0fa93d979ddec853d29d5",
-                "sha256:e0da39ff917af8b27a4bdc5a97ac577552a38aac0d260a859c1517ea3dc1a7c4",
-                "sha256:ecf6cd9f83d7c023b1aba15d13f705ca7b7d38675c121f3cc4a6e25bd0857ee9",
-                "sha256:ee0822ce1b8a14fe5a066f93edd20aada932acfe348bede8aa2149f1a4489512",
-                "sha256:f2e55a9b162e06e3f862fb61e399fe9f05d908d019d87bf5b496a04ef18a970a",
-                "sha256:f436601594f15bf406518af922a89dcaab416568edb6f65c4e5bbbad1ea45c11",
-                "sha256:f59b870db1f1ae5a9ac28245707d955c8721dd6565e7f411024fa374b5362d1d",
-                "sha256:fc533aa50664ebd6c628b2f30591956519462f5d27f951ed03d6c82b2dfd9965",
-                "sha256:fe43139b2c0fdc4a14d4f8d5b5d967f7a2777fd3d38ecf5b1ec669b0d7e43c21",
-                "sha256:fed1cd825158dcaae36acce7b2db33dcbfd12b30c34317a88b8ed80f0541cc57"
+                "sha256:00645eb79a3faa70d9cb15c8d4187bb72970b2470e938670240c7998dad9f13a",
+                "sha256:04e4ed5d1cd3eae68c89bcc1a485a109f39f2fd8de05f705e98af6b5f1861f1f",
+                "sha256:0a7d40b77f07be87c6faa93d0951a0fcd8cbca1ddff60a1b65d741bac6f3a9f6",
+                "sha256:0ece16b563b17ab26eaa2d52230c9a7ae46cf01759621f4fbbca280e438267b3",
+                "sha256:11ee4444250fcbeb47459a877e5e80ed994ce8e8d20283857fc128be1715dac7",
+                "sha256:12b0a02a91762c08f7264e2e79542f76870c3040bbc847fb67410ab81474932a",
+                "sha256:12fe8eaffaf0faa7906895b4f8bb88264035b3f0243275e0bf24af0436b27259",
+                "sha256:130fc497b8ee68dce163e4254d9b0356411d1490e868bd8790028bc46c5cc297",
+                "sha256:17ab167cca6339c2b830b744eaf10803d2a5b6683be4d79d8475d88b4a8a4be1",
+                "sha256:199207b2d3eeaeb80ef4411875a6243d9ad8bc35b07fc42daa6b801cc39cc41c",
+                "sha256:20ecc8abbd957046f1fe9562757903f5eaf57c3bce70929fda6c7711bb58074a",
+                "sha256:239736577e848678e13b201bba14e89718f5c2133dfd6b1f7846fa1b58a8532b",
+                "sha256:249590eb75ccc117f488e2fabd1bfa33c580e24b96f00658ad88e38844a040bb",
+                "sha256:27f30e14aa1c1e91cb653f03a63445739919aef84c8d2517997a83155e7a2fcc",
+                "sha256:29e7bc2eee15cbb339c68445959108803dc14ee0c7b4eea556400131a8de462b",
+                "sha256:328dbc9bff7205c215a7807da7c18dce37da7da718e798356212d22696404339",
+                "sha256:32d6d4e583593cb8576e129879ea0991660b935177c0f93c6681359b3654bfa9",
+                "sha256:3366f56c272232860ab45c77c3ca7b74ee819c8e1f6f35a7125556b198bbc6df",
+                "sha256:3434e401f3ce0ed6b42569128b3d1e3af773d7ec18751b918b89cd49c14eaafb",
+                "sha256:37d3d3f7defb13f62ece99e9be912afe9dd8a0077b7c45ee5a57c74811d581a4",
+                "sha256:3a6fd40bbb50d24976eb275ccb55cd1951dfb63dbc27cae3066a6ca5f4beabd5",
+                "sha256:3aba215958d88182e8d2acba0fdaf687745180974946609119953c0e112397dc",
+                "sha256:406520216186b99374cdb58bc48e34bb74535adec160c8459894884c983a149c",
+                "sha256:4281cd9fce9fc0a9dbf0fc1217f39bf9cf2b4d315d9626ef1d4e87b84699e7e8",
+                "sha256:42f92befc848bb7a19658f21f3e7bae80d7d005d13891c62c2cd4d4d0abb3433",
+                "sha256:48aa25e5992b61debc908a61ab4d3f216b64f44fdaa71eb082d8b2de846b7d12",
+                "sha256:5007f860c7f1f8df471e4e04aaa8c43673429047d63205d1630880f7637bca30",
+                "sha256:50a51a90610d0845a5931a780d8e51d7bd7f309ebc25132ba975aca016b576a0",
+                "sha256:51556d5004887045dba3acdd1fdf61dddea2be0a7e18048b5e853dcd37149b86",
+                "sha256:51b81e55d40c4b4aa8658427a3ee7ea847c591ae9e8b81ef94a90b668999353c",
+                "sha256:5366164391873ed76bfdf618818c82084c9db7fac82b64a20c44d335eec9ced5",
+                "sha256:54062ef956807ba806559b3c3d52105ae1827a0d4ab47b621b31132b6b7e2866",
+                "sha256:60022527e71d1d1fda67a33150ee42869042bce3d0fcc9cc49be009a9cded3fb",
+                "sha256:622d6b2c06be19f6e89b1d951485a232e3b59618def88dbeda575ed8f0d8dbf2",
+                "sha256:62cc7a30eeb0e20ecc5f4bd113cd69dcdb745a07c68c0370cea919f373f65d9e",
+                "sha256:693ed7ec72cbfcee399e92c895362b6e66d63dac6b91e2c11ae03d10d503e575",
+                "sha256:6d2404af8db1329f9a3c9b79ff63e0ae7131986446901582067d9304ae8aaf7f",
+                "sha256:7049e52167fc75fc3cc418fc13d39a8e520cbb60ca08b47f6cedb85e181d2f2a",
+                "sha256:7080c4bb3efd70a07b1cc2df99a7aa51d98685be56be6038c3169199d0a1c69f",
+                "sha256:7738027989881e70e3723c75921f1efa45225084228788fc59ea8c6d732eb30d",
+                "sha256:7a7bd57a1bb02f9d5c398c0c1675384e7ab1dd39da0ca50b7f09af45fa435277",
+                "sha256:7b3443f4ec3ba5aa00b0e9fa90cf31d98321cbff8b925a7c7b84161619870bc9",
+                "sha256:7c55b0f9f68590115c25272b06e63f0824f03d4fc7d6deed43d8ad5660cabdbf",
+                "sha256:7fd1b3879a578a8ec2076c7961076df540b9af317123f84569f5a9ddee64ce92",
+                "sha256:8076a5769d6bdf5f673a19d51da05fc79e2bbf25e9fe755c47595785c06a8c72",
+                "sha256:80f811146831c8c86ab17b640801c25dc0a88c630e855e2bef3568f30434d52b",
+                "sha256:8412eacef34cae2836d891836a7fff7b754d6bcac61f6c12ba5ca9bc7e427b68",
+                "sha256:865c8e95713744cf5ae261f3067861e9da5f1370ba91fc536431e29b418676fa",
+                "sha256:86b1e28d4c37e89220e924305cd9f82866bb0ace666943a6e4196c5df4d58dcc",
+                "sha256:891c69e027748b4a73847335d208e374ce54ca3c335907d381fde4e41661b13b",
+                "sha256:8ac164e20d17cc285f2b94dc31c384bc3aa3dd5e7490473b3db043dd70fbccfd",
+                "sha256:8c5701dc474b041e2934a26d31d39f90fac8a3dee2322b39f7729867f932b1d4",
+                "sha256:90ebb429e933645f3da534c89b29b665e285048973b4d2b6946526888c3eb2c7",
+                "sha256:923fec6e5461c42bd7e3fd5ec37492c6f3468be0499bc0707b4bbbc16ac21792",
+                "sha256:935f9edd022ec13e447e5723a7d14456c8af254544cefbc533f6dd276c9aa0d9",
+                "sha256:95ab1594377effac17110e1352989bdd7bdfca9ff0e5eeccd8c69c5389b826d0",
+                "sha256:9974d2f7dc561cce3bb88dfa8eb309dab64c729de85fba32e98d75cf24b66297",
+                "sha256:9c733cda03b6d636b4219625a4acb5c6ffb10803338e437fb614fef9516825ef",
+                "sha256:9dc001c3e10de4725c749d4c2f2bdc6ae24de5a88a339c4bce32300a31ede179",
+                "sha256:9f811079d2f9795b5d48b55a37aa7773680a5659afe34b54cc1d86590a51507d",
+                "sha256:a2726d7bfd9f76158c84c10a409b77a320426540df8c35be172444394b17f7ea",
+                "sha256:a479466da6db5c1e8754caee6c262cd373e6e6c363172d74394f4bff3d84d7b5",
+                "sha256:a543492513a93b001975ae283a51f4b67973662a375a403ae82f420d2c7205ee",
+                "sha256:a89c75a5b9bc329131115a409d0acc16e8da8dfd5867ba59f1dd66ae7ea8fa82",
+                "sha256:a8f6f72974a19efead54195bc9bed4d850fc047bb7aa971268fd9a8387c89011",
+                "sha256:a9ccbf1f129480ed3044f540c0fdbc4ee556f7175e5ab40fe077ff6baf286d4e",
+                "sha256:aa0cc8365ab29487eb4f9979fd41b22549853389e22d5de3f134a6796e1b05a4",
+                "sha256:adb4167043d3a78280d5d05ce0ba22055c266cf8655ce942f2fb881262ff3cdf",
+                "sha256:af06c863f152005c7592df1d6a7009c836a247c9d8adb78fef8575a5a98699db",
+                "sha256:b067915e3c3936966a8607f6fe5487df0c9c4afb85226613b520890049deea20",
+                "sha256:b7c5f6fe273291f4d414d55b2c80d33c457b8a42677ad14b4b47ff025d0893e4",
+                "sha256:b915daeb2d8c1f5cee4b970f2e2c988ce6514aace3c9296e58dd64dc9aa5d575",
+                "sha256:ba0e3255b0396cac3cc7bbace76404dd72b5438bf0d8e7cefa2f79a7f3649caa",
+                "sha256:bda8136e6a80bdea23e5e74e09df0362744d24ffb8cd59c4a95a6ce3d142f79c",
+                "sha256:bfe3c517c283e484843cb2e357dd57ba009cff351edf45fb455b5fbd1f45b15f",
+                "sha256:c588c45da9b08ab3da81d08d7987dae6d2a3badd63acdb3e206a42dbfa7cb76f",
+                "sha256:c600e85f2ffd9f1035222b1a312aff85fd11ea39baff1d705b9b047aad2ce267",
+                "sha256:c68e9f1fcb4d43798ad8814c4c1b61547b014b667216cb754e606bfade587018",
+                "sha256:c9649dfc57cc1f9835551deb17689e8d44666315f2e82d337b9f07bd76ae3aa2",
+                "sha256:cb45350fd1dc75cd68d3d72c47f5b513cb0578da716df5fba02fff31c69d5f2d",
+                "sha256:cbcf8630ef4afb05dc30107bfa17f16c0896bb30ee48fc24bf64c1f970f3b1fd",
+                "sha256:cbd949bdd87567b0ad183d7676feb98136cde5bb9025403794a4c0db28ed3a47",
+                "sha256:cc08ef8b90d78bfac66f0def80240b0197008e4852c9f285907377b2947ffdcb",
+                "sha256:cd17a1e489f02ce9117b0de3c0b1fab1c3e2eedc82311b299ee6b6faf6c23a29",
+                "sha256:d05686b5487cfa2e2c28ff1aa370ea3e6c5accfe6435944ddea1e10d93872147",
+                "sha256:d0e10e6f8f6dc5762adee7dece33b722282e1f59aa6a55da5d493a97282fedd8",
+                "sha256:d181ef50923c29cf0450c3cd47e2f0557b62218c50b2ab8ce2ecaa02bd97e670",
+                "sha256:d1caf40c1c657b27858f9774d5c0e232089bca9cb8ee17ce7478c6e9264d2587",
+                "sha256:d7642b9bc4827b5518ebdb3b82698ada8c14c7661ddec5fe719f3e56ccd13c97",
+                "sha256:d9481174d3ed982e269c090f780122fb59cee6c3796f74efe74e70f7780ed94c",
+                "sha256:d9ba68ec283153dead62cbe81872d28e053745f12335d037de9cbd14bd1877f5",
+                "sha256:da71945c9ace018d8634822f16cbc2a78323ef6c876b1d34bbf5d5222fd6a72e",
+                "sha256:dc44678a72ac0910bac46fa6a0de6af9ba1355669b3dfaf1ce5f05ca7a74364e",
+                "sha256:df32d59cb9780f66d165a9a7a26f19df2c7d24e3bd58713108b41d0ff4f929c6",
+                "sha256:df670918eb7dd719642e05979fc84704af913d563fd17ed636f7c4783003fdcc",
+                "sha256:e78b6ed8165996013165eeabd875c5dfc19d41b54f94b40e9fff0eb3193e5e8e",
+                "sha256:ed8fc66786de8d0376f9f913c09e963c66e90ced9aa11997f93bdb30f7c872a8",
+                "sha256:eff4b8d89f444f7e49136dc695599a591ff769300734446c0a86cba2eb2f9895",
+                "sha256:f21af781a4a6fbad54f03c598ab620e3a77032c5878f3d780448421a6e1818c7",
+                "sha256:f2bcdc54ea267fe72bfc7d83c041e4eb58d7d8dc6f578dfddb52f037ce62f432",
+                "sha256:f2f0498b7d2a3c072766dba3274fe22a183dbea1f99d188f1c6c72209a1063dc",
+                "sha256:f7208ab6e009c627b7557ce55c465c98967e8caa8b11833531fdf95799372633",
+                "sha256:f7590d5a455321e53857892ab8879dce62d1f4b04748769f5adf2e707afb9d4f",
+                "sha256:fa257a4d0d21fcbca5b5fcba9dca5a78011cb93c0323fb8855c6d2dfbc76eb77",
+                "sha256:fba9b62da882c1be1280a7584ec4515d0a6006a94d6e5819730ec2eab60ffe12",
+                "sha256:fe4371595edf78c41ef8ac8df20df3943e13defd0efcb732b2e393b5a8a7a71f"
             ],
             "markers": "python_version >= '3.9'",
-            "version": "==1.0.5"
+            "version": "==1.1.0"
         },
         "websockets": {
             "hashes": [
@@ -900,12 +935,20 @@
         },
         "flake8": {
             "hashes": [
-                "sha256:93b92ba5bdb60754a6da14fa3b93a9361fd00a59632ada61fd7b130436c40343",
-                "sha256:fa558ae3f6f7dbf2b4f22663e5343b6b6023620461f8d4ff2019ef4b5ee70426"
+                "sha256:b9696257b9ce8beb888cdbe31cf885c90d31928fe202be0889a7cdafad32f01e",
+                "sha256:fe044858146b9fc69b551a4b490d69cf960fcb78ad1edcb84e7fbb1b4a8e3872"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.9'",
-            "version": "==7.2.0"
+            "version": "==7.3.0"
+        },
+        "iniconfig": {
+            "hashes": [
+                "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7",
+                "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==2.1.0"
         },
         "isort": {
             "hashes": [
@@ -956,21 +999,46 @@
             "markers": "python_version >= '3.9'",
             "version": "==4.3.8"
         },
-        "pycodestyle": {
+        "pluggy": {
             "hashes": [
-                "sha256:35863c5974a271c7a726ed228a14a4f6daf49df369d8c50cd9a6f58a5e143ba9",
-                "sha256:c8415bf09abe81d9c7f872502a6eee881fbe85d8763dd5b9924bb0a01d67efae"
+                "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3",
+                "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746"
             ],
             "markers": "python_version >= '3.9'",
-            "version": "==2.13.0"
+            "version": "==1.6.0"
+        },
+        "pycodestyle": {
+            "hashes": [
+                "sha256:c4b5b517d278089ff9d0abdec919cd97262a3367449ea1c8b49b91529167b783",
+                "sha256:dd6bf7cb4ee77f8e016f9c8e74a35ddd9f67e1d5fd4184d86c3b98e07099f42d"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==2.14.0"
         },
         "pyflakes": {
             "hashes": [
-                "sha256:5039c8339cbb1944045f4ee5466908906180f13cc99cc9949348d10f82a5c32a",
-                "sha256:6dfd61d87b97fba5dcfaaf781171ac16be16453be6d816147989e7f6e6a9576b"
+                "sha256:b24f96fafb7d2ab0ec5075b7350b3d2d2218eab42003821c06344973d3ea2f58",
+                "sha256:f742a7dbd0d9cb9ea41e9a24a918996e8170c799fa528688d40dd582c8265f4f"
             ],
             "markers": "python_version >= '3.9'",
-            "version": "==3.3.2"
+            "version": "==3.4.0"
+        },
+        "pygments": {
+            "hashes": [
+                "sha256:61c16d2a8576dc0649d9f39e089b5f02bcd27fba10d8fb4dcc28173f7a45151f",
+                "sha256:9ea1544ad55cecf4b8242fab6dd35a93bbce657034b0611ee383099054ab6d8c"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==2.19.1"
+        },
+        "pytest": {
+            "hashes": [
+                "sha256:539c70ba6fcead8e78eebbf1115e8b589e7565830d7d006a8723f19ac8a0afb7",
+                "sha256:7c67fd69174877359ed9371ec3af8a3d2b04741818c51e5e99cc1742251fa93c"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.9'",
+            "version": "==8.4.1"
         },
         "pytoolconfig": {
             "extras": [

--- a/client/git-integration/components/tabs/WorkspaceTab.vue
+++ b/client/git-integration/components/tabs/WorkspaceTab.vue
@@ -1,3 +1,4 @@
+<!-- client/git-integration/components/tabs/WorkspaceTab.vue -->
 <template>
   <div class="flex h-full flex-col">
     <!-- Main Content Area (Scrollable) -->
@@ -64,6 +65,40 @@
           >
             Commit & Sync
           </button>
+        </div>
+      </div>
+
+      <!-- NEW: .gitignore Helper Message -->
+      <div
+        v-if="showGitignoreHelper"
+        class="mx-2 mb-4 rounded-md border border-blue-500/30 bg-blue-500/10 p-3 text-sm"
+      >
+        <div class="flex items-start">
+          <SvgIcon
+            type="mdi"
+            :path="mdiInformationOutline"
+            :size="20"
+            class="mr-2 mt-0.5 flex-shrink-0 text-blue-400"
+          />
+          <div>
+            <h4 class="font-semibold text-theme-text">
+              A .gitignore file is present
+            </h4>
+            <p class="mt-1 text-xs text-theme-text-muted">
+              This file tells Git to ignore certain files, like the app's cache.
+              It was automatically created to ensure a clean repository.
+            </p>
+            <p class="mt-2 text-xs text-theme-text-muted">
+              It's recommended to
+              <a
+                href="#"
+                @click.prevent="stageAndPrefillCommit"
+                class="font-semibold text-theme-brand hover:underline"
+                >stage and commit this file</a
+              >
+              to keep your workspace clean.
+            </p>
+          </div>
         </div>
       </div>
 
@@ -273,7 +308,11 @@ import {
   mdilArrowUp,
   mdilArrowDown,
 } from "@mdi/light-js";
-import { mdiCheck, mdiAlertCircleOutline } from "@mdi/js";
+import {
+  mdiCheck,
+  mdiAlertCircleOutline,
+  mdiInformationOutline,
+} from "@mdi/js";
 
 const statusStore = useStatusStore();
 const actionsStore = useActionsStore();
@@ -281,6 +320,22 @@ const actionsStore = useActionsStore();
 const isBranchMenuVisible = ref(false);
 const branchData = ref({ branches: [], current_branch: "" });
 const upstreamWarningPanel = ref();
+
+// --- .gitignore Helper ---
+const gitignoreFile = computed(() => {
+  return statusStore.gitStatus.files.find((f) => f.path === ".gitignore");
+});
+
+const showGitignoreHelper = computed(() => {
+  return gitignoreFile.value && gitignoreFile.value.work_tree_status !== " ";
+});
+
+function stageAndPrefillCommit() {
+  actionsStore.handleStageFile(".gitignore");
+  if (!statusStore.commitMessage) {
+    statusStore.commitMessage = "chore: Initialize .gitignore";
+  }
+}
 
 // --- Computed Properties for Button States & Titles ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,8 @@
       "devDependencies": {
         "@vitejs/plugin-vue": "5.2.3",
         "autoprefixer": "10.4.21",
+        "husky": "^9.1.7",
+        "lint-staged": "^16.1.2",
         "postcss": "8.5.3",
         "prettier": "3.5.3",
         "prettier-plugin-tailwindcss": "0.6.11",
@@ -362,6 +364,22 @@
       "version": "3.5.13",
       "license": "MIT"
     },
+    "node_modules/ansi-escapes": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.0.0.tgz",
+      "integrity": "sha512-GdYO7a61mR0fOlAsvC9/rIHf7L96sBc6dEWzeOu+KAea5bZyQRPIpojrVoI4AXGJS/ycu/fBTdLrUkA4ODrvjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "environment": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "6.1.0",
       "dev": true,
@@ -570,6 +588,19 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chalk": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
+      "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
     "node_modules/chokidar": {
       "version": "3.6.0",
       "dev": true,
@@ -604,6 +635,64 @@
         "node": ">= 6"
       }
     },
+    "node_modules/cli-cursor": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-4.0.0.tgz",
+      "integrity": "sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "slice-ansi": "^5.0.0",
+        "string-width": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/emoji-regex": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
+      "integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cli-truncate/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "dev": true,
@@ -617,6 +706,13 @@
     },
     "node_modules/color-name": {
       "version": "1.1.4",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/colorette": {
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
       "dev": true,
       "license": "MIT"
     },
@@ -681,6 +777,24 @@
       "version": "3.1.3",
       "license": "MIT"
     },
+    "node_modules/debug": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "license": "MIT",
@@ -737,6 +851,19 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/environment": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+      "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/es-define-property": {
@@ -825,6 +952,13 @@
     },
     "node_modules/estree-walker": {
       "version": "2.0.2",
+      "license": "MIT"
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -935,6 +1069,19 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.3.0.tgz",
+      "integrity": "sha512-vpeMIQKxczTD/0s2CdEWHcb0eeJe6TFjxb+J5xgX7hScxqrGuyjmv4c1D4A/gelKfyox0gJJwIHF+fLjeaM8kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-intrinsic": {
@@ -1049,6 +1196,22 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/immutable": {
@@ -1171,6 +1334,201 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lint-staged": {
+      "version": "16.1.2",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-16.1.2.tgz",
+      "integrity": "sha512-sQKw2Si2g9KUZNY3XNvRuDq4UJqpHwF0/FQzZR2M7I5MvtpWvibikCjUVJzZdGE0ByurEl3KQNvsGetd1ty1/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.4.1",
+        "commander": "^14.0.0",
+        "debug": "^4.4.1",
+        "lilconfig": "^3.1.3",
+        "listr2": "^8.3.3",
+        "micromatch": "^4.0.8",
+        "nano-spawn": "^1.0.2",
+        "pidtree": "^0.6.0",
+        "string-argv": "^0.3.2",
+        "yaml": "^2.8.0"
+      },
+      "bin": {
+        "lint-staged": "bin/lint-staged.js"
+      },
+      "engines": {
+        "node": ">=20.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/lint-staged"
+      }
+    },
+    "node_modules/lint-staged/node_modules/commander": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.0.tgz",
+      "integrity": "sha512-2uM9rYjPvyq39NwLRqaiLtWHyDC1FvryJDa2ATTVims5YAS4PupsEQsDvP14FqhFr0P49CYDugi59xaxJlTXRA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/listr2": {
+      "version": "8.3.3",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-8.3.3.tgz",
+      "integrity": "sha512-LWzX2KsqcB1wqQ4AHgYb4RsDXauQiqhjLk+6hjbaeHG4zpjjVAB6wC/gz6X0l+Du1cN3pUB5ZlrvTbhGSNnUQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cli-truncate": "^4.0.0",
+        "colorette": "^2.0.20",
+        "eventemitter3": "^5.0.1",
+        "log-update": "^6.1.0",
+        "rfdc": "^1.4.1",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/listr2/node_modules/emoji-regex": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
+      "integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/listr2/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/listr2/node_modules/wrap-ansi": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.0.tgz",
+      "integrity": "sha512-G8ura3S+3Z2G+mkgNRq8dqaFZAuxfsxpBB8OCTGRTCtp+l/v9nbFNmCUP1BZMts3G1142MsZfn6eeUKrr4PD1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/log-update": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz",
+      "integrity": "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-escapes": "^7.0.0",
+        "cli-cursor": "^5.0.0",
+        "slice-ansi": "^7.1.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/emoji-regex": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
+      "integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/log-update/node_modules/is-fullwidth-code-point": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.0.0.tgz",
+      "integrity": "sha512-OVa3u9kkBbw7b8Xw5F9P+D/T9X+Z4+JruYVNapTjPYZYUznQ5YfWeFkOj606XYYW8yugTfC8Pj0hYqvi4ryAhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/slice-ansi": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.0.tgz",
+      "integrity": "sha512-bSiSngZ/jWeX93BqeIAbImyTbEihizcwNjFoRUIY/T1wWQsfsm2Vw1agPKylXvQTU7iASGdHhyqRlqQzfz+Htg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "is-fullwidth-code-point": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/wrap-ansi": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.0.tgz",
+      "integrity": "sha512-G8ura3S+3Z2G+mkgNRq8dqaFZAuxfsxpBB8OCTGRTCtp+l/v9nbFNmCUP1BZMts3G1142MsZfn6eeUKrr4PD1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "10.4.3",
       "dev": true,
@@ -1227,6 +1585,19 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/minimatch": {
       "version": "9.0.5",
       "dev": true,
@@ -1253,6 +1624,13 @@
       "version": "1.6.5",
       "license": "Apache-2.0 WITH LLVM-exception"
     },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/mz": {
       "version": "2.7.0",
       "dev": true,
@@ -1261,6 +1639,19 @@
         "any-promise": "^1.0.0",
         "object-assign": "^4.0.1",
         "thenify-all": "^1.0.0"
+      }
+    },
+    "node_modules/nano-spawn": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/nano-spawn/-/nano-spawn-1.0.2.tgz",
+      "integrity": "sha512-21t+ozMQDAL/UGgQVBbZ/xXvNO10++ZPuTmKRO8k9V3AClVRht49ahtDjfY8l1q6nSHOrE5ASfthzH3ol6R/hg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.17"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/nano-spawn?sponsor=1"
       }
     },
     "node_modules/nanoid": {
@@ -1316,6 +1707,22 @@
         "node": ">= 6"
       }
     },
+    "node_modules/onetime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/orderedmap": {
       "version": "2.1.1",
       "license": "MIT"
@@ -1366,6 +1773,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pidtree": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.6.0.tgz",
+      "integrity": "sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "pidtree": "bin/pidtree.js"
+      },
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/pify": {
@@ -1772,6 +2192,23 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/restore-cursor": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^7.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/reusify": {
       "version": "1.1.0",
       "dev": true,
@@ -1780,6 +2217,13 @@
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/rollup": {
       "version": "4.38.0",
@@ -1956,11 +2400,51 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/slice-ansi": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-5.0.0.tgz",
+      "integrity": "sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.0.0",
+        "is-fullwidth-code-point": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/is-fullwidth-code-point": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz",
+      "integrity": "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/string-argv": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
+      "integrity": "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.19"
       }
     },
     "node_modules/string-width": {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
   "description": "A database-less note taking web app that utilises a flat folder of markdown files for storage.",
   "main": "client/index.html",
   "scripts": {
+    "git-test": "pipenv run pytest",
+    "prepare": "husky",
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "vite build",
     "watch": "vite build --watch",
@@ -30,6 +32,8 @@
   "devDependencies": {
     "@vitejs/plugin-vue": "5.2.3",
     "autoprefixer": "10.4.21",
+    "husky": "^9.1.7",
+    "lint-staged": "^16.1.2",
     "postcss": "8.5.3",
     "prettier": "3.5.3",
     "prettier-plugin-tailwindcss": "0.6.11",
@@ -44,7 +48,8 @@
     "*.{json,html,css,scss,md}": "prettier --write",
     "*.py": [
       "pipenv run isort",
-      "pipenv run black"
+      "pipenv run black",
+      "pipenv run flake8"
     ]
   }
 }

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,7 +1,3 @@
 export default {
   plugins: ["prettier-plugin-tailwindcss"],
-  endOfLine: "lf",
-  singleQuote: false,
-  semi: true,
-  tabWidth: 2,
 };

--- a/server/git_integration/git_manager.py
+++ b/server/git_integration/git_manager.py
@@ -403,6 +403,20 @@ class GitManager:
             logger.error(error_message)
             raise GitManagerError(error_message)
 
+    def _get_commit_diff(self, commit: pygit2.Commit) -> pygit2.Diff:
+        """
+        A helper method to get the diff of a commit against its parent.
+        It correctly handles the initial commit case (which has no parent).
+        """
+        parent = commit.parents[0] if commit.parents else None
+
+        if parent:
+            # If there's a parent, diff against its tree
+            return commit.tree.diff_to_tree(parent.tree)
+        else:
+            # This is the initial commit, diff against an empty tree
+            return commit.tree.diff_to_tree()
+
     def commit(self, message: Optional[str]) -> Dict[str, Any]:
         """
         Creates a commit and returns structured data about it.
@@ -447,10 +461,8 @@ class GitManager:
         if os.path.exists(merge_head_path):
             os.remove(merge_head_path)
 
-        # Get file list for the new commit
         new_commit = self.repo.get(commit_oid)
-        parent_tree = new_commit.parents[0].tree if new_commit.parents else None
-        commit_diff = self.repo.diff(parent_tree, new_commit.tree)
+        commit_diff = self._get_commit_diff(new_commit)
         files_changed = self._get_diff_files(commit_diff)
 
         return {
@@ -644,8 +656,6 @@ class GitManager:
                 files_changed = self._get_diff_files(diff)
 
         command = ["push", remote, branch_to_push]
-        if force:
-            command.append("--force")
 
         output = self._run_git_command(command)
         return {
@@ -695,9 +705,7 @@ class GitManager:
 
     def get_files_in_commit(self, commit_hash: str) -> List[Dict[str, str]]:
         commit = self.repo.get(commit_hash)
-        parent_tree = commit.parents[0].tree if commit.parents else None
-
-        diff = self.repo.diff(parent_tree, commit.tree)
+        diff = self._get_commit_diff(commit)
 
         diff.find_similar()
 
@@ -714,6 +722,7 @@ class GitManager:
             return self.default_branch
         if self.repo.head_is_detached:
             return f"DETACHED ({str(self.repo.head.target)[:7]})"
+
         return self.repo.head.shorthand
 
     def fetch_and_list_branches(self) -> Dict[str, Any]:
@@ -721,6 +730,7 @@ class GitManager:
             self._run_git_command(["fetch", self.default_remote, "--prune"])
         except GitManagerError:
             pass
+
         return self.list_branches()
 
     def list_branches(self) -> Dict[str, Any]:
@@ -740,6 +750,7 @@ class GitManager:
                 branches.append(
                     {"name": branch_part, "is_active": False, "is_remote": True}
                 )
+
         branches.sort(key=lambda x: (x["is_remote"], x["name"]))
         return {"branches": branches, "current_branch": active_branch_name}
 
@@ -750,18 +761,27 @@ class GitManager:
             )
         if branch_name in self.repo.branches.local:
             self.repo.checkout(self.repo.branches.local[branch_name])
-        else:
-            remote_branch = self.repo.branches.remote[
-                f"{self.default_remote}/{branch_name}"
-            ]
+            return
+
+        try:
+            remote_branch_name = f"{self.default_remote}/{branch_name}"
+            remote_branch = self.repo.branches.remote[remote_branch_name]
+
             local_branch = self.repo.create_branch(branch_name, remote_branch.peel())
             local_branch.upstream = remote_branch
             self.repo.checkout(local_branch)
 
+        except KeyError:
+            raise BranchNotFoundError(
+                f"Branch '{branch_name}' not found locally or on remote '{self.default_remote}'."
+            )
+
     def checkout_file_from_commit(self, commit_hash: str, filepath: str):
         commit = self.repo.get(commit_hash)
+
         if not isinstance(commit, pygit2.Commit):
             raise GitError(f"Hash '{commit_hash}' is not a commit.")
+
         self.repo.checkout_tree(
             treeish=commit.tree, paths=[filepath], strategy=pygit2.GIT_CHECKOUT_FORCE
         )
@@ -771,11 +791,15 @@ class GitManager:
     ):
         if self.repo.head_is_detached:
             raise GitManagerError("Cannot reset in detached HEAD state.")
+
         local_branch_name = branch_name or self.get_current_branch()
         local_branch = self.repo.branches.local[local_branch_name]
+
         if not local_branch.upstream:
             raise GitManagerError("Branch has no upstream to reset to.")
+
         self._run_git_command(["fetch", remote_name or self.default_remote])
         upstream_commit = self.repo.lookup_reference(local_branch.upstream.name).peel()
         self.repo.reset(upstream_commit.id, pygit2.GIT_RESET_HARD)
+
         return {"message": f"Reset branch '{local_branch_name}' to remote state."}

--- a/server/git_integration/git_manager.py
+++ b/server/git_integration/git_manager.py
@@ -624,7 +624,6 @@ class GitManager:
         self,
         remote_name: Optional[str] = None,
         branch: Optional[str] = None,
-        force: bool = False,
     ) -> Dict[str, Any]:
         remote = remote_name or self.default_remote
         branch_to_push = branch or self.get_current_branch()
@@ -632,7 +631,7 @@ class GitManager:
             raise GitManagerError("Cannot push in a detached HEAD state.")
 
         ahead, _ = self.get_ahead_behind()
-        if ahead == 0 and not force:
+        if ahead == 0:
             return {"message": "Nothing to push."}
 
         commits_to_push = []
@@ -705,6 +704,9 @@ class GitManager:
 
     def get_files_in_commit(self, commit_hash: str) -> List[Dict[str, str]]:
         commit = self.repo.get(commit_hash)
+        if commit is None:
+            raise GitError(f"Object not found for hash '{commit_hash}'")
+
         diff = self._get_commit_diff(commit)
 
         diff.find_similar()
@@ -781,6 +783,9 @@ class GitManager:
 
         if not isinstance(commit, pygit2.Commit):
             raise GitError(f"Hash '{commit_hash}' is not a commit.")
+
+        if filepath not in commit.tree:
+            raise KeyError(f"File '{filepath}' not found in commit '{commit_hash}'")
 
         self.repo.checkout_tree(
             treeish=commit.tree, paths=[filepath], strategy=pygit2.GIT_CHECKOUT_FORCE

--- a/server/git_integration/test/test_git_manager.py
+++ b/server/git_integration/test/test_git_manager.py
@@ -1,0 +1,478 @@
+# server/git_integration/test/test_git_manager.py
+
+import os
+import subprocess
+
+import pytest
+from pygit2 import GitError
+
+from ..git_config import PullStrategy
+from ..git_manager import (
+    GitManager,
+    GitManagerError,
+    NoChangesError,
+    PushRejectedError,
+)
+
+# --- Fixtures: Test Setup Utilities ---
+
+
+@pytest.fixture
+def manager_and_path(tmp_path):
+    repo_path = tmp_path / "test_repo"
+    repo_path.mkdir()
+
+    subprocess.run(["git", "init"], cwd=repo_path, check=True)
+    subprocess.run(
+        ["git", "config", "user.name", "Test User"], cwd=repo_path, check=True
+    )
+    subprocess.run(
+        ["git", "config", "user.email", "test@example.com"], cwd=repo_path, check=True
+    )
+
+    subprocess.run(
+        ["git", "commit", "--allow-empty", "-m", "Initial empty commit"],
+        cwd=repo_path,
+        check=True,
+    )
+    subprocess.run(["git", "branch", "-M", "main"], cwd=repo_path, check=True)
+
+    manager = GitManager(
+        repo_path=str(repo_path),
+        default_branch="main",
+        default_remote="origin",
+        pull_strategy=PullStrategy.REBASE,
+        user_name="Test User",
+        user_email="test@example.com",
+    )
+    return manager, str(repo_path)
+
+
+@pytest.fixture
+def repo_with_remote(tmp_path):
+    local_repo_path = tmp_path / "local_repo"
+    remote_repo_path = tmp_path / "remote_repo.git"
+
+    subprocess.run(["git", "init", "--bare", str(remote_repo_path)], check=True)
+    subprocess.run(
+        ["git", "clone", str(remote_repo_path), str(local_repo_path)], check=True
+    )
+
+    local_path_str = str(local_repo_path)
+    subprocess.run(
+        ["git", "config", "user.name", "Test User"], cwd=local_path_str, check=True
+    )
+    subprocess.run(
+        ["git", "config", "user.email", "test@example.com"],
+        cwd=local_path_str,
+        check=True,
+    )
+
+    subprocess.run(["git", "checkout", "-b", "main"], cwd=local_path_str, check=True)
+    with open(os.path.join(local_path_str, "README.md"), "w") as f:
+        f.write("# Test Repository\n")
+    subprocess.run(["git", "add", "README.md"], cwd=local_path_str, check=True)
+    subprocess.run(
+        ["git", "commit", "-m", "Initial commit"], cwd=local_path_str, check=True
+    )
+    subprocess.run(
+        ["git", "push", "-u", "origin", "main"], cwd=local_path_str, check=True
+    )
+
+    manager = GitManager(
+        repo_path=local_path_str,
+        default_branch="main",
+        default_remote="origin",
+        pull_strategy=PullStrategy.REBASE,
+        user_name="Test User",
+        user_email="test@example.com",
+    )
+    return manager, local_path_str, str(remote_repo_path)
+
+
+# --- Helper Function ---
+
+
+def run_git(repo_path, command):
+    result = subprocess.run(
+        ["git"] + command, cwd=repo_path, check=True, capture_output=True, text=True
+    )
+    return result.stdout.strip()
+
+
+# --- Test Classes ---
+
+
+class TestInitialization:
+    def test_initialization_creates_gitignore(self, manager_and_path):
+        manager, repo_path = manager_and_path
+        gitignore_path = os.path.join(repo_path, ".gitignore")
+        assert os.path.exists(gitignore_path)
+        with open(gitignore_path, "r") as f:
+            assert ".flatnotes/" in f.read()
+
+
+class TestCommit:
+    def test_commit_no_staged_changes_raises_error(self, manager_and_path):
+        manager, _ = manager_and_path
+        with pytest.raises(NoChangesError):
+            manager.commit("This should fail")
+
+    def test_commit_with_staged_files_succeeds(self, manager_and_path):
+        manager, repo_path = manager_and_path
+        with open(os.path.join(repo_path, "note.md"), "w") as f:
+            f.write("# A new note")
+        manager.add_all()
+
+        commit_details = manager.commit("feat: Add note and gitignore")
+
+        assert "hash" in commit_details
+        paths_in_commit = {f["path"] for f in commit_details["files_changed"]}
+        assert paths_in_commit == {".gitignore", "note.md"}
+        status_output = run_git(repo_path, ["status", "--porcelain"])
+        assert status_output == ""
+
+
+class TestFileOperations:
+    def test_add_all_stages_all_new_files(self, manager_and_path):
+        manager, repo_path = manager_and_path
+        with open(os.path.join(repo_path, "file1.md"), "w") as f:
+            f.write("1")
+        with open(os.path.join(repo_path, "file2.md"), "w") as f:
+            f.write("2")
+        manager.add_all()
+        status_output = run_git(repo_path, ["status", "--porcelain"])
+        assert "A  .gitignore" in status_output
+        assert "A  file1.md" in status_output
+        assert "A  file2.md" in status_output
+
+    def test_unstage_file_moves_it_from_index_to_workspace(self, manager_and_path):
+        manager, repo_path = manager_and_path
+        file_path = "staged_file.md"
+        with open(os.path.join(repo_path, file_path), "w") as f:
+            f.write("content")
+        run_git(repo_path, ["add", file_path])
+        status_before = run_git(repo_path, ["status", "--porcelain"])
+        assert f"A  {file_path}" in status_before.splitlines()
+        manager.unstage_file(file_path)
+        status_after = run_git(repo_path, ["status", "--porcelain"])
+        assert f"?? {file_path}" in status_after.splitlines()
+
+    def test_discard_file_removes_untracked_file(self, manager_and_path):
+        manager, repo_path = manager_and_path
+        file_path = os.path.join(repo_path, "untracked.md")
+        with open(file_path, "w") as f:
+            f.write("delete me")
+        assert os.path.exists(file_path)
+        manager.discard_file("untracked.md")
+        assert not os.path.exists(file_path)
+
+    def test_discard_all_cleans_workspace(self, manager_and_path):
+        manager, repo_path = manager_and_path
+        run_git(repo_path, ["add", ".gitignore"])
+        run_git(repo_path, ["commit", "-m", "Initial"])
+        with open(os.path.join(repo_path, ".gitignore"), "a") as f:
+            f.write("\n# modified")
+        with open(os.path.join(repo_path, "new_file.md"), "w") as f:
+            f.write("new")
+        manager.discard_all()
+        status_output_after = run_git(repo_path, ["status", "--porcelain"])
+        assert status_output_after == ""
+
+    def test_checkout_file_from_commit_restores_file(self, manager_and_path):
+        manager, repo_path = manager_and_path
+        file_to_restore = "file_to_restore.md"
+        path = os.path.join(repo_path, file_to_restore)
+        with open(path, "w") as f:
+            f.write("Version 1")
+        run_git(repo_path, ["add", "."])
+        run_git(repo_path, ["commit", "-m", "v1"])
+        commit1_hash = run_git(repo_path, ["rev-parse", "HEAD"])
+        with open(path, "w") as f:
+            f.write("Version 2")
+        run_git(repo_path, ["commit", "-am", "v2"])
+        manager.checkout_file_from_commit(commit1_hash, file_to_restore)
+        with open(path, "r") as f:
+            assert f.read() == "Version 1"
+
+    def test_checkout_invalid_commit_raises_error(self, manager_and_path):
+        manager, _ = manager_and_path
+        with pytest.raises(GitError):
+            manager.checkout_file_from_commit("a" * 40, "anyfile.txt")
+
+
+class TestRepositoryState:
+    def _setup_conflict_scenario(self, repo_path):
+        with open(os.path.join(repo_path, "file.txt"), "w") as f:
+            f.write("initial version\n")
+        run_git(repo_path, ["add", "."])
+        run_git(repo_path, ["commit", "--amend", "-m", "Initial commit"])
+        run_git(repo_path, ["checkout", "-b", "other"])
+        with open(os.path.join(repo_path, "file.txt"), "a") as f:
+            f.write("change from other\n")
+        run_git(repo_path, ["commit", "-am", "Commit on other"])
+        run_git(repo_path, ["checkout", "main"])
+        with open(os.path.join(repo_path, "file.txt"), "a") as f:
+            f.write("change from main\n")
+        run_git(repo_path, ["commit", "-am", "Commit on main"])
+
+    def test_get_repository_state_merge_conflict(self, manager_and_path):
+        manager, repo_path = manager_and_path
+        self._setup_conflict_scenario(repo_path)
+        try:
+            subprocess.run(
+                ["git", "merge", "other"],
+                cwd=repo_path,
+                check=True,
+                capture_output=True,
+            )
+        except subprocess.CalledProcessError:
+            pass
+        state = manager.get_repository_state()
+        assert state == "MERGING_CONFLICT"
+        assert "file.txt" in manager.get_conflicted_files()
+
+    def test_get_repository_state_rebase_conflict(self, manager_and_path):
+        manager, repo_path = manager_and_path
+        self._setup_conflict_scenario(repo_path)
+        run_git(repo_path, ["checkout", "other"])
+        try:
+            subprocess.run(
+                ["git", "rebase", "main"],
+                cwd=repo_path,
+                check=True,
+                capture_output=True,
+            )
+        except subprocess.CalledProcessError:
+            pass
+        state = manager.get_repository_state()
+        assert state == "REBASING_CONFLICT"
+        assert "file.txt" in manager.get_conflicted_files()
+
+    def test_abort_conflict_resolution_aborts_merge(self, manager_and_path):
+        manager, repo_path = manager_and_path
+        self._setup_conflict_scenario(repo_path)
+        try:
+            subprocess.run(
+                ["git", "merge", "other"],
+                cwd=repo_path,
+                check=True,
+                capture_output=True,
+            )
+        except subprocess.CalledProcessError:
+            pass
+        manager.abort_conflict_resolution()
+        assert manager.get_repository_state() == "CLEAN"
+        status_output = run_git(repo_path, ["status", "--porcelain"])
+        assert "M  file.txt" in status_output
+
+    def test_continue_conflict_resolution_completes_merge(self, manager_and_path):
+        manager, repo_path = manager_and_path
+        self._setup_conflict_scenario(repo_path)
+        try:
+            subprocess.run(
+                ["git", "merge", "other"],
+                cwd=repo_path,
+                check=True,
+                capture_output=True,
+            )
+        except subprocess.CalledProcessError:
+            pass
+        with open(os.path.join(repo_path, "file.txt"), "w") as f:
+            f.write("resolved version\n")
+        run_git(repo_path, ["add", "file.txt"])
+        assert manager.get_repository_state() == "MERGING"
+        result = manager.continue_conflict_resolution()
+        assert "Merge finalized" in result["message"]
+        assert manager.get_repository_state() == "CLEAN"
+        log_output = run_git(repo_path, ["log", "-1", "--pretty=%s"])
+        assert "Merge branch 'other'" in log_output
+
+    def test_continue_resolution_in_clean_state_raises_error(self, manager_and_path):
+        manager, _ = manager_and_path
+        with pytest.raises(GitManagerError):
+            manager.continue_conflict_resolution()
+
+
+class TestRemoteOperations:
+    def test_push_succeeds_when_ahead(self, repo_with_remote):
+        manager, local_path, remote_path = repo_with_remote
+        with open(os.path.join(local_path, "local_change.txt"), "w") as f:
+            f.write("local content")
+        run_git(local_path, ["add", "."])
+        run_git(local_path, ["commit", "-m", "Local commit"])
+        manager.push_local_changes()
+        remote_head_hash = run_git(remote_path, ["rev-parse", "main"])
+        remote_log_subject = run_git(
+            remote_path, ["show", "-s", "--format=%s", remote_head_hash]
+        )
+        assert remote_log_subject == "Local commit"
+
+    def test_pull_succeeds_when_behind(self, repo_with_remote):
+        manager, local_path, remote_path = repo_with_remote
+        temp_clone_path = os.path.join(os.path.dirname(remote_path), "temp_clone")
+        run_git(
+            os.path.dirname(remote_path),
+            ["clone", "-b", "main", remote_path, temp_clone_path],
+        )
+        run_git(temp_clone_path, ["config", "user.name", "Remote Actor"])
+        run_git(temp_clone_path, ["config", "user.email", "remote@example.com"])
+        with open(os.path.join(temp_clone_path, "remote_change.txt"), "w") as f:
+            f.write("remote content")
+        run_git(temp_clone_path, ["add", "."])
+        run_git(temp_clone_path, ["commit", "-m", "Remote commit"])
+        run_git(temp_clone_path, ["push", "origin", "main"])
+        manager.pull_remote_changes()
+        local_log = run_git(local_path, ["log", "-1", "--pretty=%s"])
+        assert local_log == "Remote commit"
+
+    def test_sync_workspace_full_cycle(self, repo_with_remote):
+        manager, local_path, remote_path = repo_with_remote
+        temp_clone_path = os.path.join(os.path.dirname(remote_path), "temp_clone_sync")
+        run_git(
+            os.path.dirname(remote_path),
+            ["clone", "-b", "main", remote_path, temp_clone_path],
+        )
+        run_git(temp_clone_path, ["config", "user.name", "Remote Actor"])
+        run_git(temp_clone_path, ["config", "user.email", "remote@example.com"])
+        with open(os.path.join(temp_clone_path, "remote_sync.txt"), "w") as f:
+            f.write("remote")
+        run_git(temp_clone_path, ["add", "."])
+        run_git(temp_clone_path, ["commit", "-m", "Remote for sync"])
+        run_git(temp_clone_path, ["push", "origin", "main"])
+        with open(os.path.join(local_path, "local_sync.txt"), "w") as f:
+            f.write("local")
+        sync_results = manager.sync_workspace("feat: Full sync operation")
+        assert "hash" in sync_results["commit"]
+        remote_log = run_git(remote_path, ["log", "main", "--pretty=%s"])
+        assert "feat: Full sync operation" in remote_log
+        assert "Remote for sync" in remote_log
+
+    def test_reset_to_remote_discards_local_commits(self, repo_with_remote):
+        manager, local_path, remote_path = repo_with_remote
+        run_git(local_path, ["commit", "--allow-empty", "-m", "Local commit 1"])
+        run_git(local_path, ["commit", "--allow-empty", "-m", "Local commit 2"])
+        manager.reset_to_remote()
+        local_log_after = run_git(local_path, ["log", "--oneline"])
+        remote_log = run_git(remote_path, ["log", "main", "--oneline"])
+        assert local_log_after == remote_log
+
+    def test_pull_with_merge_strategy_creates_merge_commit(self, repo_with_remote):
+        _, local_path, remote_path = repo_with_remote
+        manager = GitManager(
+            repo_path=local_path,
+            default_branch="main",
+            default_remote="origin",
+            pull_strategy=PullStrategy.MERGE,
+        )
+        temp_clone_path = os.path.join(os.path.dirname(remote_path), "temp_clone_merge")
+        run_git(
+            os.path.dirname(remote_path),
+            ["clone", "-b", "main", remote_path, temp_clone_path],
+        )
+        run_git(temp_clone_path, ["config", "user.name", "Remote Actor"])
+        run_git(temp_clone_path, ["config", "user.email", "remote@example.com"])
+        with open(os.path.join(temp_clone_path, "remote_file.txt"), "w") as f:
+            f.write("r")
+        run_git(temp_clone_path, ["add", "."])
+        run_git(temp_clone_path, ["commit", "-m", "Remote change"])
+        run_git(temp_clone_path, ["push", "origin", "main"])
+        with open(os.path.join(local_path, "local_file.txt"), "w") as f:
+            f.write("l")
+        run_git(local_path, ["add", "."])
+        run_git(local_path, ["commit", "-m", "Local change"])
+        manager.pull_remote_changes()
+        local_log = run_git(local_path, ["log", "-1", "--pretty=%s"])
+        assert "Merge branch 'main' of" in local_log
+
+    def test_push_non_fast_forward_raises_push_rejected_error(self, repo_with_remote):
+        manager, local_path, remote_path = repo_with_remote
+        with open(os.path.join(local_path, "local_file.txt"), "w") as f:
+            f.write("l")
+        run_git(local_path, ["add", "."])
+        run_git(local_path, ["commit", "-m", "Local change"])
+        temp_clone_path = os.path.join(os.path.dirname(remote_path), "temp_clone_ff")
+        run_git(
+            os.path.dirname(remote_path),
+            ["clone", "-b", "main", remote_path, temp_clone_path],
+        )
+        run_git(temp_clone_path, ["config", "user.name", "Remote Actor"])
+        run_git(temp_clone_path, ["config", "user.email", "remote@example.com"])
+        with open(os.path.join(temp_clone_path, "remote_file.txt"), "w") as f:
+            f.write("r")
+        run_git(temp_clone_path, ["add", "."])
+        run_git(temp_clone_path, ["commit", "-m", "Remote change"])
+        run_git(temp_clone_path, ["push", "origin", "main"])
+        with pytest.raises(PushRejectedError):
+            manager.push_local_changes()
+
+
+class TestReadOnlyOperations:
+    def test_get_commit_log_returns_commits(self, manager_and_path):
+        manager, repo_path = manager_and_path
+        with open(os.path.join(repo_path, "file1.md"), "w") as f:
+            f.write("1")
+        run_git(repo_path, ["add", "."])
+        run_git(repo_path, ["commit", "-m", "Second Commit"])
+        with open(os.path.join(repo_path, "file2.md"), "w") as f:
+            f.write("2")
+        run_git(repo_path, ["add", "."])
+        run_git(repo_path, ["commit", "-m", "Third Commit"])
+        log_entries = manager.get_commit_log(limit=5)
+        assert len(log_entries) == 3
+        assert log_entries[0]["message"] == "Third Commit"
+        assert log_entries[1]["message"] == "Second Commit"
+        assert log_entries[2]["message"] == "Initial empty commit"
+
+    def test_get_files_in_commit_returns_correct_files(self, manager_and_path):
+        manager, repo_path = manager_and_path
+        with open(os.path.join(repo_path, "note1.md"), "w") as f:
+            f.write("a")
+        with open(os.path.join(repo_path, "note2.md"), "w") as f:
+            f.write("b")
+        run_git(repo_path, ["add", "note1.md", "note2.md"])
+        run_git(repo_path, ["commit", "-m", "Add two notes"])
+        commit_hash = run_git(repo_path, ["rev-parse", "HEAD"])
+        files = manager.get_files_in_commit(commit_hash)
+        assert len(files) == 2
+        paths = {f["path"] for f in files}
+        assert paths == {"note1.md", "note2.md"}
+
+    def test_get_files_in_initial_commit(self, manager_and_path):
+        manager, repo_path = manager_and_path
+        run_git(repo_path, ["add", ".gitignore"])
+        run_git(repo_path, ["commit", "--amend", "-m", "Initial commit with file"])
+        first_commit_hash = run_git(repo_path, ["rev-list", "--max-parents=0", "HEAD"])
+        files = manager.get_files_in_commit(first_commit_hash)
+        assert len(files) == 1
+        assert files[0]["path"] == ".gitignore"
+
+    def test_list_branches_returns_local_and_remote(self, repo_with_remote):
+        manager, local_path, remote_path = repo_with_remote
+        run_git(local_path, ["checkout", "-b", "local-feature"])
+        temp_clone_path = os.path.join(
+            os.path.dirname(remote_path), "temp_clone_branch"
+        )
+        run_git(
+            os.path.dirname(remote_path),
+            ["clone", "-b", "main", remote_path, temp_clone_path],
+        )
+        run_git(temp_clone_path, ["checkout", "-b", "remote-feature"])
+        run_git(temp_clone_path, ["commit", "--allow-empty", "-m", "feat on remote"])
+        run_git(temp_clone_path, ["push", "origin", "remote-feature"])
+        branch_info = manager.fetch_and_list_branches()
+        branches = branch_info["branches"]
+        branch_names = {b["name"] for b in branches}
+        assert {"main", "local-feature", "remote-feature"}.issubset(branch_names)
+
+    def test_switch_branch_changes_head(self, manager_and_path):
+        manager, repo_path = manager_and_path
+        run_git(repo_path, ["checkout", "-b", "new-feature"])
+        manager.switch_branch("main")
+        current_branch_after = run_git(repo_path, ["branch", "--show-current"])
+        assert current_branch_after == "main"
+
+    def test_switch_to_non_existent_branch_raises_error(self, manager_and_path):
+        manager, _ = manager_and_path
+        with pytest.raises(GitManagerError):
+            manager.switch_branch("non-existent-branch")

--- a/server/git_integration/test/test_git_manager.py
+++ b/server/git_integration/test/test_git_manager.py
@@ -21,7 +21,6 @@ from ..git_manager import (
 def manager_and_path(tmp_path):
     repo_path = tmp_path / "test_repo"
     repo_path.mkdir()
-
     subprocess.run(["git", "init"], cwd=repo_path, check=True)
     subprocess.run(
         ["git", "config", "user.name", "Test User"], cwd=repo_path, check=True
@@ -29,14 +28,12 @@ def manager_and_path(tmp_path):
     subprocess.run(
         ["git", "config", "user.email", "test@example.com"], cwd=repo_path, check=True
     )
-
     subprocess.run(
         ["git", "commit", "--allow-empty", "-m", "Initial empty commit"],
         cwd=repo_path,
         check=True,
     )
     subprocess.run(["git", "branch", "-M", "main"], cwd=repo_path, check=True)
-
     manager = GitManager(
         repo_path=str(repo_path),
         default_branch="main",
@@ -52,12 +49,10 @@ def manager_and_path(tmp_path):
 def repo_with_remote(tmp_path):
     local_repo_path = tmp_path / "local_repo"
     remote_repo_path = tmp_path / "remote_repo.git"
-
     subprocess.run(["git", "init", "--bare", str(remote_repo_path)], check=True)
     subprocess.run(
         ["git", "clone", str(remote_repo_path), str(local_repo_path)], check=True
     )
-
     local_path_str = str(local_repo_path)
     subprocess.run(
         ["git", "config", "user.name", "Test User"], cwd=local_path_str, check=True
@@ -67,7 +62,6 @@ def repo_with_remote(tmp_path):
         cwd=local_path_str,
         check=True,
     )
-
     subprocess.run(["git", "checkout", "-b", "main"], cwd=local_path_str, check=True)
     with open(os.path.join(local_path_str, "README.md"), "w") as f:
         f.write("# Test Repository\n")
@@ -78,7 +72,6 @@ def repo_with_remote(tmp_path):
     subprocess.run(
         ["git", "push", "-u", "origin", "main"], cwd=local_path_str, check=True
     )
-
     manager = GitManager(
         repo_path=local_path_str,
         default_branch="main",
@@ -123,9 +116,7 @@ class TestCommit:
         with open(os.path.join(repo_path, "note.md"), "w") as f:
             f.write("# A new note")
         manager.add_all()
-
         commit_details = manager.commit("feat: Add note and gitignore")
-
         assert "hash" in commit_details
         paths_in_commit = {f["path"] for f in commit_details["files_changed"]}
         assert paths_in_commit == {".gitignore", "note.md"}
@@ -167,6 +158,20 @@ class TestFileOperations:
         manager.discard_file("untracked.md")
         assert not os.path.exists(file_path)
 
+    def test_discard_file_resets_tracked_file(self, manager_and_path):
+        manager, repo_path = manager_and_path
+        file_path = "tracked_file.md"
+        full_path = os.path.join(repo_path, file_path)
+        with open(full_path, "w") as f:
+            f.write("initial content")
+        run_git(repo_path, ["add", file_path])
+        run_git(repo_path, ["commit", "-m", "add tracked file"])
+        with open(full_path, "w") as f:
+            f.write("modified content")
+        manager.discard_file(file_path)
+        with open(full_path, "r") as f:
+            assert f.read() == "initial content"
+
     def test_discard_all_cleans_workspace(self, manager_and_path):
         manager, repo_path = manager_and_path
         run_git(repo_path, ["add", ".gitignore"])
@@ -199,6 +204,12 @@ class TestFileOperations:
         manager, _ = manager_and_path
         with pytest.raises(GitError):
             manager.checkout_file_from_commit("a" * 40, "anyfile.txt")
+
+    def test_checkout_nonexistent_file_raises_error(self, manager_and_path):
+        manager, repo_path = manager_and_path
+        commit_hash = run_git(repo_path, ["rev-parse", "HEAD"])
+        with pytest.raises(KeyError):
+            manager.checkout_file_from_commit(commit_hash, "nonexistent_file.txt")
 
 
 class TestRepositoryState:
@@ -287,6 +298,44 @@ class TestRepositoryState:
         assert manager.get_repository_state() == "CLEAN"
         log_output = run_git(repo_path, ["log", "-1", "--pretty=%s"])
         assert "Merge branch 'other'" in log_output
+
+    def test_abort_conflict_resolution_aborts_rebase(self, manager_and_path):
+        manager, repo_path = manager_and_path
+        self._setup_conflict_scenario(repo_path)
+        run_git(repo_path, ["checkout", "other"])
+        try:
+            subprocess.run(
+                ["git", "rebase", "main"],
+                cwd=repo_path,
+                check=True,
+                capture_output=True,
+            )
+        except subprocess.CalledProcessError:
+            pass
+        manager.abort_conflict_resolution()
+        assert manager.get_repository_state() == "CLEAN"
+        log_output = run_git(repo_path, ["log", "-1", "--pretty=%s"])
+        assert log_output == "Initial commit"
+
+    def test_continue_conflict_resolution_completes_rebase(self, manager_and_path):
+        manager, repo_path = manager_and_path
+        self._setup_conflict_scenario(repo_path)
+        run_git(repo_path, ["checkout", "other"])
+        try:
+            subprocess.run(
+                ["git", "rebase", "main"],
+                cwd=repo_path,
+                check=True,
+                capture_output=True,
+            )
+        except subprocess.CalledProcessError:
+            pass
+        with open(os.path.join(repo_path, "file.txt"), "w") as f:
+            f.write("resolved version\n")
+        run_git(repo_path, ["add", "file.txt"])
+        result = manager.continue_conflict_resolution()
+        assert "Rebase finished" in result["message"]
+        assert manager.get_repository_state() == "CLEAN"
 
     def test_continue_resolution_in_clean_state_raises_error(self, manager_and_path):
         manager, _ = manager_and_path
@@ -385,6 +434,34 @@ class TestRemoteOperations:
         local_log = run_git(local_path, ["log", "-1", "--pretty=%s"])
         assert "Merge branch 'main' of" in local_log
 
+    def test_pull_with_rebase_strategy_rebases_commits(self, repo_with_remote):
+        manager, local_path, remote_path = (
+            repo_with_remote  # This manager uses rebase strategy
+        )
+        temp_clone_path = os.path.join(
+            os.path.dirname(remote_path), "temp_clone_rebase"
+        )
+        run_git(
+            os.path.dirname(remote_path),
+            ["clone", "-b", "main", remote_path, temp_clone_path],
+        )
+        run_git(temp_clone_path, ["config", "user.name", "Remote Actor"])
+        run_git(temp_clone_path, ["config", "user.email", "remote@example.com"])
+        with open(os.path.join(temp_clone_path, "remote_file.txt"), "w") as f:
+            f.write("r")
+        run_git(temp_clone_path, ["add", "."])
+        run_git(temp_clone_path, ["commit", "-m", "Remote change"])
+        run_git(temp_clone_path, ["push", "origin", "main"])
+        with open(os.path.join(local_path, "local_file.txt"), "w") as f:
+            f.write("l")
+        run_git(local_path, ["add", "."])
+        run_git(local_path, ["commit", "-m", "Local change"])
+        manager.pull_remote_changes()
+        local_log = run_git(local_path, ["log", "--oneline", "-n", "2"])
+        assert "Local change" in local_log
+        assert "Remote change" in local_log
+        assert local_log.find("Local change") < local_log.find("Remote change")
+
     def test_push_non_fast_forward_raises_push_rejected_error(self, repo_with_remote):
         manager, local_path, remote_path = repo_with_remote
         with open(os.path.join(local_path, "local_file.txt"), "w") as f:
@@ -447,6 +524,12 @@ class TestReadOnlyOperations:
         assert len(files) == 1
         assert files[0]["path"] == ".gitignore"
 
+    def test_get_files_in_commit_with_invalid_hash(self, manager_and_path):
+        manager, _ = manager_and_path
+        invalid_hash = "a" * 40
+        with pytest.raises(GitError):
+            manager.get_files_in_commit(invalid_hash)
+
     def test_list_branches_returns_local_and_remote(self, repo_with_remote):
         manager, local_path, remote_path = repo_with_remote
         run_git(local_path, ["checkout", "-b", "local-feature"])
@@ -474,5 +557,7 @@ class TestReadOnlyOperations:
 
     def test_switch_to_non_existent_branch_raises_error(self, manager_and_path):
         manager, _ = manager_and_path
-        with pytest.raises(GitManagerError):
+        from ..git_manager import BranchNotFoundError
+
+        with pytest.raises(BranchNotFoundError):
             manager.switch_branch("non-existent-branch")


### PR DESCRIPTION
Implement a full suite of integration tests for the GitManager class,
covering all core functionalities including local operations, remote
interactions, conflict resolution, and read-only queries.

## Summary by Sourcery

Add a full suite of integration tests for GitManager, introduce a .gitignore helper in the workspace UI, refactor internal diff and branch logic, and update development tooling with pytest, flake8, and pre-commit hooks

New Features:
- Introduce comprehensive integration tests for GitManager covering local operations, remote sync, conflict handling, and read-only queries
- Add a .gitignore helper panel in the WorkspaceTab UI to guide users and automate staging

Enhancements:
- Refactor GitManager to centralize commit diff computation via a new _get_commit_diff helper
- Improve branch switching logic to provide clearer errors when branches are not found

Build:
- Add pytest to dev dependencies in Pipfile and configure flake8 checks in lint-staged pre-commit hooks
- Update package.json with a git-test script and prepare script for Husky

CI:
- Introduce Husky pre-commit hooks and lint-staged rules for formatting and linting Python and frontend files

Tests:
- Add server/git_integration/test/test_git_manager.py with extensive integration tests for GitManager functionality

Chores:
- Remove custom prettier settings from prettier.config.js