### PR TITLE
CI: Publish Docker image on tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ name: Continuous Integration
 on:
   pull_request:
     branches:
-      - git-Integration
+      - git-integration
 
 jobs:
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@
 name: Continuous Integration
 
 # --- Triggers ---
-# This workflow runs on pull requests that target the 'main' branch.
+# This workflow runs on pull requests that target the 'git-Integration' branch.
 on:
   pull_request:
     branches:
@@ -24,19 +24,18 @@ jobs:
         with:
           python-version: '3.11'
 
-      - name: Cache Pipenv dependencies
-        id: cache-pipenv
+      - name: Cache pip cache
         uses: actions/cache@v4
         with:
-          path: ~/.local/share/virtualenvs
-          key: ${{ runner.os }}-pipenv-${{ hashFiles('**/Pipfile.lock') }}
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/Pipfile.lock') }}
           restore-keys: |
-            ${{ runner.os }}-pipenv-
+            ${{ runner.os }}-pip-
 
       - name: Install Pipenv and Python dependencies
         run: |
           pip install pipenv
-          pipenv install --dev --system
+          pipenv install --dev
 
       # --- 3. Set up Node.js and Cache npm Dependencies ---
       - name: Set up Node.js

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,61 @@
+# .github/workflows/ci.yml
+
+name: Continuous Integration
+
+# --- Triggers ---
+# This workflow runs on pull requests that target the 'main' branch.
+on:
+  pull_request:
+    branches:
+      - git-Integration
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      # --- 1. Checkout Code ---
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # --- 2. Set up Python and Cache Pipenv Dependencies ---
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Cache Pipenv dependencies
+        id: cache-pipenv
+        uses: actions/cache@v4
+        with:
+          path: ~/.local/share/virtualenvs
+          key: ${{ runner.os }}-pipenv-${{ hashFiles('**/Pipfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pipenv-
+
+      - name: Install Pipenv and Python dependencies
+        run: |
+          pip install pipenv
+          pipenv install --dev --system
+
+      # --- 3. Set up Node.js and Cache npm Dependencies ---
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20' # A recent LTS version
+
+      - name: Cache npm dependencies
+        id: cache-npm
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - name: Install npm dependencies
+        run: npm ci # 'ci' is faster and more reliable for CI environments
+
+      # --- 4. Run Tests ---
+      - name: Run Python and JS tests
+        run: npm run git-test

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,68 +1,57 @@
-# .github/workflows/docker-publish.yml
+# .github/workflows/docker-image.yml
 
 name: Docker Publish on Tag
 
-# --- Trigger: This workflow runs only when a new tag is pushed ---
-# We use tags like v1.0.0, v1.1.0, etc., to trigger releases.
+# This workflow runs on:
+# 1. A new tag push (e.g., v1.0.0)
+# 2. A manual trigger from the GitHub Actions UI
 on:
   push:
     tags:
-      - 'v*.*.*' # Matches tags like v1.0.0, v1.2.3
+      - 'v*.*.*'
+  workflow_dispatch:
 
 jobs:
   build-and-push:
-    runs-on: ubuntu-latest # Use the latest Ubuntu runner environment
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
 
+    env:
+      # Centralize the image name for easy updates.
+      IMAGE_NAME: ${{ secrets.DOCKERHUB_USERNAME }}/flatnotes-git
+
     steps:
-      # --- Step 1: Check out your repository code ---
-      # This downloads your source code into the runner so it can be built.
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      # --- Step 2: Set up QEMU for multi-platform builds ---
-      # (Optional but recommended) This allows you to build images for different
-      # architectures, like arm64 for Raspberry Pi users.
-      - name: Set up QEMU
+      - name: Set up QEMU for multi-platform builds
         uses: docker/setup-qemu-action@v3
 
-      # --- Step 3: Set up Docker Buildx ---
-      # Buildx is a Docker CLI plugin that extends 'docker build' with more
-      # features, including multi-platform builds.
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      # --- Step 4: Log in to Docker Hub ---
-      # This step uses the secrets you created earlier to authenticate.
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      # --- Step 5: Extract metadata (tags and labels) from the Git tag ---
-      # This clever action automatically figures out the Docker image tags.
-      # For a Git tag like 'v1.2.3', it will generate Docker tags:
-      # - yourusername/flatnotes-git:latest
-      # - yourusername/flatnotes-git:1.2.3
-      # - yourusername/flatnotes-git:1.2
-      # - yourusername/flatnotes-git:1
+      # This action automatically creates tags like 'latest', '1.2.3', '1.2'
       - name: Extract metadata for Docker
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ secrets.DOCKERHUB_USERNAME }}/flatnotes-git
+          images: ${{ env.IMAGE_NAME }}
 
-      # --- Step 6: Build and push the Docker image ---
-      # This is the main event. It builds your Dockerfile and pushes the
-      # resulting image to Docker Hub with all the tags generated above.
+      # This step builds the Dockerfile and pushes it to Docker Hub
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
         with:
-          context: . # Use the current directory as the build context
-          push: true # Actually push the image to the registry
-          tags: ${{ steps.meta.outputs.tags }} # Use the tags from the 'meta' step
-          labels: ${{ steps.meta.outputs.labels }} # Add standard labels
-          platforms: linux/amd64,linux/arm64 # Build for both common architectures
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          # Build for both common CPU architectures
+          platforms: linux/amd64,linux/arm64

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,68 @@
+# .github/workflows/docker-publish.yml
+
+name: Docker Publish on Tag
+
+# --- Trigger: This workflow runs only when a new tag is pushed ---
+# We use tags like v1.0.0, v1.1.0, etc., to trigger releases.
+on:
+  push:
+    tags:
+      - 'v*.*.*' # Matches tags like v1.0.0, v1.2.3
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest # Use the latest Ubuntu runner environment
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      # --- Step 1: Check out your repository code ---
+      # This downloads your source code into the runner so it can be built.
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # --- Step 2: Set up QEMU for multi-platform builds ---
+      # (Optional but recommended) This allows you to build images for different
+      # architectures, like arm64 for Raspberry Pi users.
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      # --- Step 3: Set up Docker Buildx ---
+      # Buildx is a Docker CLI plugin that extends 'docker build' with more
+      # features, including multi-platform builds.
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # --- Step 4: Log in to Docker Hub ---
+      # This step uses the secrets you created earlier to authenticate.
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      # --- Step 5: Extract metadata (tags and labels) from the Git tag ---
+      # This clever action automatically figures out the Docker image tags.
+      # For a Git tag like 'v1.2.3', it will generate Docker tags:
+      # - yourusername/flatnotes-git:latest
+      # - yourusername/flatnotes-git:1.2.3
+      # - yourusername/flatnotes-git:1.2
+      # - yourusername/flatnotes-git:1
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ secrets.DOCKERHUB_USERNAME }}/flatnotes-git
+
+      # --- Step 6: Build and push the Docker image ---
+      # This is the main event. It builds your Dockerfile and pushes the
+      # resulting image to Docker Hub with all the tags generated above.
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: . # Use the current directory as the build context
+          push: true # Actually push the image to the registry
+          tags: ${{ steps.meta.outputs.tags }} # Use the tags from the 'meta' step
+          labels: ${{ steps.meta.outputs.labels }} # Add standard labels
+          platforms: linux/amd64,linux/arm64 # Build for both common architectures

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,3 @@
 # .husky/pre-commit
 
 npx lint-staged
-npm run git-test


### PR DESCRIPTION
## Summary by Sourcery

Add GitHub Actions workflows for continuous integration and Docker image publishing

New Features:
- Run Python and JavaScript tests on pull requests targeting the main branch
- Publish multi-platform Docker images to Docker Hub on version tag pushes

Enhancements:
- Cache Pipenv and npm dependencies in CI to speed up builds
- Enable QEMU and Buildx for amd64 and arm64 Docker builds